### PR TITLE
Use new streaming interface from servicex

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "funcx",
         "minio",
         "nanoevents",
+        "pytest",
         "qastle",
         "servicex",
         "xaod"

--- a/notebooks/DaskAnalysis.ipynb
+++ b/notebooks/DaskAnalysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,13 +15,12 @@
     "\n",
     "from servicex import ServiceXDataset\n",
     "from sx_multi import FuncAdlDataset\n",
-    "from coffea import hist, processor\n",
-    "\n"
+    "from coffea import hist, processor"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +57,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +66,6 @@
     "        self.accumulator = Accumulator({\n",
     "            \"mass\": hist.Hist(\n",
     "                \"Events\",\n",
-    "                hist.Cat(\"dataset\", \"Dataset\"),\n",
     "                hist.Bin(\"mass\", \"$Z_{ee}$ [GeV]\", 60, 60, 120),\n",
     "            ),\n",
     "        })\n",
@@ -85,7 +83,6 @@
     "\n",
     "        output[\"sumw\"][dataset] += len(events)\n",
     "        output[\"mass\"].fill(\n",
-    "            dataset=dataset,\n",
     "            mass=diele.mass,\n",
     "        )\n",
     "\n",
@@ -93,37 +90,40 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We create the analysis and executor. The `DaskExecutor` can be done two ways:\n",
+    "\n",
+    "- `DaskExecutor()` which creates a local cluster. All data will be pulled down to the local machine via an `uproot.open`. This can be paiful depending on what your connection looks like.\n",
+    "- `DaskExecutor(client_addr=\"node.name.edu:8080\")` which will attach to a remote `dask` cluster. This is particularly powerful if the `dask` cluster is located close to the `servicex` installation."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = Z_EEAnalysis()\n",
+    "executor = DaskExecutor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/bengal1/.local/share/virtualenvs/funcx_coffea/lib/python3.7/site-packages/distributed/client.py:1129: VersionMismatchWarning: Mismatched versions found\n",
-      "\n",
-      "+-------------+--------+-----------+---------+\n",
-      "| Package     | client | scheduler | workers |\n",
-      "+-------------+--------+-----------+---------+\n",
-      "| blosc       | None   | 1.9.2     | None    |\n",
-      "| distributed | 2.30.1 | 2.30.0    | None    |\n",
-      "| tornado     | 6.1    | 6.0.4     | None    |\n",
-      "+-------------+--------+-----------+---------+\n",
-      "  warnings.warn(version_module.VersionMismatchWarning(msg[0][\"warning\"]))\n"
+      "c:\\users\\gordo\\documents\\code\\iris-hep\\servicex-coffea-multiprocessing\\.venv\\lib\\site-packages\\distributed\\node.py:151: UserWarning: Port 8787 is already in use.\n",
+      "Perhaps you already have a cluster running?\n",
+      "Hosting the HTTP server on port 65247 instead\n",
+      "  warnings.warn(\n"
      ]
-    }
-   ],
-   "source": [
-    "analysis = Z_EEAnalysis()\n",
-    "executor = DaskExecutor(client_addr=\"127.0.0.1:8080\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [
+    },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
@@ -141,28 +141,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "56aa2a102ab14f71a386c0c8fe65b5a3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(HTML(value='        Downloaded'), FloatProgress(value=0.0, layout=Layout(flex='2'), max=9000000…"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'mass': <Hist (dataset,mass) instance at 0x12a8d6c90>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 24000.0})}\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fd5b43a8d6d34c8cbc17887b3453c1c2",
+       "model_id": "2f7a489a4c5d498da7950256940fb1b1",
        "version_major": 2,
        "version_minor": 0
       },
@@ -172,39 +151,6 @@
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'mass': <Hist (dataset,mass) instance at 0x12aa19d50>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 45000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ab2f0d0>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 50000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ab63810>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 50000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ab9ae90>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 50000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12aa07910>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 125000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ac08690>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ac57ad0>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12acaf550>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 149800.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12abff450>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ad341d0>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12abffdd0>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ad0e6d0>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ac3df10>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ad34190>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ac3dc50>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n",
-      "{'mass': <Hist (dataset,mass) instance at 0x12ad97910>, 'sumw': defaultdict_accumulator(<class 'float'>, {'mc15x': 150000.0})}\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'mass': <Hist (dataset,mass) instance at 0x12a07d590>,\n",
-       " 'sumw': defaultdict_accumulator(float, {'mc15x': 1993800.0})}"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -213,18 +159,42 @@
     "  async for coffea_info in accumulator_stream:\n",
     "    # Need to ask coffea folks how to anomate this!\n",
     "    hist.plot1d(coffea_info['mass'])\n",
-    "    plt.show()\n",
     "  return coffea_info\n",
     "\n",
-    "await plot_stream(executor.execute(analysis, datasource))"
+    "result = await plot_stream(executor.execute(analysis, datasource))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 53,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1b6c2ba6bfb0469e8d1016a9f0ead3df",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%matplotlib widget\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "data = np.random.normal(size=100)\n",
+    "fig, axes = plt.subplots()\n",
+    "for _ in range(10):\n",
+    "    plt.hist(data)\n",
+    "    # display(fig)\n",
+    "sleep(10)"
+   ]
   }
  ],
  "metadata": {
@@ -243,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/DaskAnalysis.ipynb
+++ b/notebooks/DaskAnalysis.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,12 +15,14 @@
     "\n",
     "from servicex import ServiceXDataset\n",
     "from sx_multi import FuncAdlDataset\n",
-    "from coffea import hist, processor"
+    "from coffea import hist, processor\n",
+    "\n",
+    "from IPython.display import update_display"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,20 +112,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This next method makes an updating plot, as the data appears. If you didn't want the fancy updating plot, you could do `await executor.execute(analysis, datasource)`, and you'd end up with the coffea dict when that cell completed."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "c:\\users\\gordo\\documents\\code\\iris-hep\\servicex-coffea-multiprocessing\\.venv\\lib\\site-packages\\distributed\\node.py:151: UserWarning: Port 8787 is already in use.\n",
-      "Perhaps you already have a cluster running?\n",
-      "Hosting the HTTP server on port 65247 instead\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
@@ -140,13 +139,9 @@
     },
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2f7a489a4c5d498da7950256940fb1b1",
-       "version_major": 2,
-       "version_minor": 0
-      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZsAAAEKCAYAAADEovgeAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/Il7ecAAAACXBIWXMAAAsTAAALEwEAmpwYAAAl+0lEQVR4nO3de5hU1Znv8e8rIOClRYSQlosNCWPSIrbQcjFREW+oGVtziCImgvGIHiHKGZ8YyUwOXhJHJz5jxJNBiSLgKKgYhORRgRG8cAaRJiEYWpQWL3SnBQS1NQQQ854/9qq2aKr6vru6qn+f56mn9n732rvWslveXmuvWtvcHRERkTgdkukKiIhI7lOyERGR2CnZiIhI7JRsREQkdko2IiISOyUbERGJXce4LmxmxwNPJIUGAP8HmBfiBcC7wKXu/pGZGXAfcAGwG5jo7n8I15oA/Eu4zs/dfW6IDwXmAF2BZ4EbvZ653D169PCCgoLmN1BEpJ1Yt27dh+7esznXsNb4no2ZdQAqgeHAZGCXu99lZrcAR7v7T8zsAuBHRMlmOHCfuw83s+5AKVAMOLAOGBoS1GvADcAaomQzw92fq6suxcXFXlpaGk9DRURykJmtc/fi5lyjtYbRzgLedvf3gBJgbojPBS4O2yXAPI+8CnQzs3zgPGC5u+9y94+A5cCYcCzP3V8NvZl5SdcSEZE2pLWSzThgftju5e5VYfsDoFfY7g1sTTqnIsTqilekiIuISBsTe7Ixs0OBi4Cnah8LPZLYx/HMbJKZlZpZ6Y4dO+L+OBERqSW2CQJJzgf+4O7bwv42M8t396owFLY9xCuBvknn9QmxSmBUrfiLId4nRfmDuPssYBZE92ya0xgRaR8+//xzKioq2LNnT6ar0mq6dOlCnz596NSpU4tfuzWSzeV8OYQGsASYANwV3hcnxaeY2QKiCQKfhIS0FLjTzI4O5c4Fprn7LjOrNrMRRBMErgTuj785ItIeVFRUcOSRR1JQUEA0WTa3uTs7d+6koqKC/v37t/j1Yx1GM7PDgXOA3yaF7wLOMbPNwNlhH6LZZFuAcuA3wPUA7r4LuANYG163hxihzEPhnLeBOmeiiYg01J49ezjmmGPaRaIBMDOOOeaY2HpysfZs3P2vwDG1YjuJZqfVLutE06JTXWc2MDtFvBQY1CKVFRGppbGJ5rIHVwPwxLUj46hO7OJMrFpBQESkjTIzbrrpppr9e+65h1tvvTVzFWqG1rhnIyL1eHzN+yxeH81vKauqBqAwPw+AkqLejB/eL2N1k8zp3Lkzv/3tb5k2bRo9evTIdHWaRT0bkTZg8frKA5JMItGUVVXXJCFpfzp27MikSZO49957Dzr27rvvMnr0aAYPHsxZZ53F+++/D8DEiRO54YYbOPXUUxkwYAALFy6sOeeXv/wlp5xyCoMHD2b69Omt1g5Qz0akzSjMzztorD9xD0Ay67bfbaTsL9UHxRN/ICTs3rsfgBNvXXpAPPHHwwGxY/OY/o8n1PvZkydPZvDgwdx8880HxH/0ox8xYcIEJkyYwOzZs7nhhht45plnAKiqqmLVqlVs2rSJiy66iLFjx7Js2TI2b97Ma6+9hrtz0UUX8fLLL3P66afXW4eWoJ6NiEgblpeXx5VXXsmMGTMOiK9evZrx48cD8IMf/IBVq1bVHLv44os55JBDKCwsZNu26CuOy5YtY9myZZx88skMGTKETZs2sXnz5lZrh3o2IiL1aEgPBOKbjTZ16lSGDBnCVVdd1aDynTt3rtlOLLbs7kybNo1rr722RevWUOrZiIi0cd27d+fSSy/l4YcfromdeuqpLFiwAIDHHnuM0047rc5rnHfeecyePZvPPvsMgMrKSrZv317nOS1JyUZEJAvcdNNNfPjhhzX7999/P4888giDBw/m0Ucf5b777qvz/HPPPZfx48czcuRITjzxRMaOHcunn34ad7VraBhNRKSNSvRCAHr16sXu3btr9o877jhWrFhx0Dlz5sxJe40bb7yRG2+8seUr2gBKNiIiLSRbVw5oDRpGExGR2CnZiIhI7JRsRETSSEwbbi/ibK+SjYhICl26dGHnzp3tJuEknmfTpUuXWK6vCQIiIin06dOHiooK2tOj5BNP6oyDko1IG1dWVV2z1pZWgm49nTp1iuWJle2Vko1IK0r3KIGyquqUizWWFPU+oGzytpKNZBMlG5FWlHiUQO3EUpifV5NYko0f3u+gpKKVoCUbKdmItLJUjxIQyXWajSYiIrFTshERkdgp2YiISOxiTTZm1s3MFprZJjN7w8xGmll3M1tuZpvD+9GhrJnZDDMrN7MNZjYk6ToTQvnNZjYhKT7UzF4P58wwM4uzPSIi0jRx92zuA553928AJwFvALcAL7j7QOCFsA9wPjAwvCYBMwHMrDswHRgODAOmJxJUKHNN0nljYm6PiIg0QWzJxsyOAk4HHgZw933u/jFQAswNxeYCF4ftEmCeR14FuplZPnAesNzdd7n7R8ByYEw4lufur3q0nsS8pGuJiEgbEmfPpj+wA3jEzP5oZg+Z2eFAL3evCmU+AHqF7d7A1qTzK0KsrnhFivhBzGySmZWaWWl7WnpCRKStiDPZdASGADPd/WTgr3w5ZAZA6JHEvsqdu89y92J3L+7Zs2fcHyciIrXEmWwqgAp3XxP2FxIln21hCIzwvj0crwT6Jp3fJ8TqivdJEReRNuqDDz5g3LhxfO1rX2Po0KFccMEFvPXWW7z44ot85zvfaZHPePfddxk0aFCLXCvhqaee4pvf/CZnnnlmneUmTpzIwoUL6ywzZ84c/vKXvzS5Ljt37uTMM8/kiCOOYMqUKTXxTz/9lKKioppXjx49mDp1apM/p6XFlmzc/QNgq5kdH0JnAWXAEiAxo2wCsDhsLwGuDLPSRgCfhOG2pcC5ZnZ0mBhwLrA0HKs2sxFhFtqVSdcSkTbG3bnkkksYNWoUb7/9NuvWreNf//Vf2bZtW6arVq+HH36Y3/zmN6xcubLZ12pusunSpQt33HEH99xzzwHxI488kvXr19e8jjvuOL773e82t7otJu7ZaD8CHjOzDUARcCdwF3COmW0Gzg77AM8CW4By4DfA9QDuvgu4A1gbXreHGKHMQ+Gct4HnYm6PiDTRypUr6dSpE9ddd11N7KSTTuK0004D4LPPPmPs2LF84xvf4Iorrqh5jkxBQQEffvghAKWlpYwaNQqAW2+9lR/+8IeMGjWKAQMGMGPGjIM+c8uWLZx88smsXbuWjRs3MmzYMIqKihg8eDCbN28+qPz8+fM58cQTGTRoED/5yU8AuP3221m1ahVXX301P/7xjw8o7+5MmTKF448/nrPPPpvt27fXHLv99ts55ZRTGDRoEJMmTcLdWbhwIaWlpVxxxRUUFRXxt7/9LWW5uhx++OF8+9vfrvO5M2+99Rbbt2+v+W/bJrh7u3oNHTrURTLl0gf+2y994L8zfo1MuO+++3zq1Kkpj61cudLz8vJ869at/sUXX/iIESP8lVdecXf34447znfs2OHu7mvXrvUzzjjD3d2nT5/uI0eO9D179viOHTu8e/fuvm/fPn/nnXf8hBNO8E2bNnlRUZGvX7/e3d2nTJni//mf/+nu7nv37vXdu3cfUIfKykrv27evb9++3T///HM/88wzfdGiRe7ufsYZZ/jatWsPqvfTTz/tZ599tu/fv98rKyv9qKOO8qeeesrd3Xfu3FlT7vvf/74vWbIk5bXSlZs5c6bPnDkz7X/PRx55xCdPnpzy2G233eY33XRT2nMbCyj1Zv7bqxUERKRNGDZsGH369OGQQw6hqKiId999t95zLrzwQjp37kyPHj34yle+UjMkt2PHDkpKSnjsscc46aSTABg5ciR33nknd999N++99x5du3Y94Fpr165l1KhR9OzZk44dO3LFFVfw8ssv1/n5L7/8MpdffjkdOnTg2GOPZfTo0TXHVq5cyfDhwznxxBNZsWIFGzduTHmNdOWuu+66A3qBjbFgwQIuv/zyJp0bFyUbEWkVJ5xwAuvWrUt7vHPnzjXbHTp0YP/+/QB07NiRv//97wDs2bOnQeccddRR9OvXj1WrVtUcHz9+PEuWLKFr165ccMEFrFixovmNSmPPnj1cf/31LFy4kNdff51rrrnmoLo3plxj/OlPf2L//v0MHTq0WddpaUo2ItIqRo8ezd69e5k1a1ZNbMOGDbzyyit1nldQUFCTpJ5++ukGfdahhx7KokWLmDdvHo8//jgQ3b8ZMGAAN9xwAyUlJWzYsOGAc4YNG8ZLL73Ehx9+yBdffMH8+fM544wz6vyc008/nSeeeIIvvviCqqqqmgkEiYTRo0cPPvvsswNmqB155JF8+umn9ZZrqvnz57e5Xg3oeTYi0krMjEWLFjF16lTuvvtuunTpQkFBAb/61a+orEz/rYXp06dz9dVX87Of/axmckBDHH744fz+97/nnHPO4YgjjqCsrIxHH32UTp068dWvfpWf/vSnB5TPz8/nrrvu4swzz8TdufDCCykpKanzMy655BJWrFhBYWEh/fr1Y+TI6DlF3bp145prrmHQoEF89atf5ZRTTqk5Z+LEiVx33XV07dqV1atXpy33wAMPAKQcSisoKKC6upp9+/bxzDPPsGzZMgoLCwF48sknefbZZxv836m1mNcz8yHXFBcXe2lpaaarIe1U4imbzXl4WktcQ6QxzGyduxc35xoaRhMRkdgp2YiISOyUbEREJHZKNiIiEjslGxERiZ2SjYiIxE7JRkREYqdkIyIisVOyERGR2CnZiIhI7JRsREQkdko2IiISOyUbERGJnR4xIBKTx9e8z+L10dL5ZVXVNfHC/LxMVUkkY9SzEYnJ4vWVByQZiBJNSVHvDNVIJHPUsxGJUWF+np47I0LMPRsze9fMXjez9WZWGmLdzWy5mW0O70eHuJnZDDMrN7MNZjYk6ToTQvnNZjYhKT40XL88nGtxtkdERJqmNYbRznT3oqSnvN0CvODuA4EXwj7A+cDA8JoEzIQoOQHTgeHAMGB6IkGFMtcknTcm/uaIiEhjZeKeTQkwN2zPBS5Ois/zyKtANzPLB84Dlrv7Lnf/CFgOjAnH8tz9VY+ebT0v6VoiItKGxJ1sHFhmZuvMbFKI9XL3qrD9AdArbPcGtiadWxFidcUrUsRFRKSNiXuCwLfdvdLMvgIsN7NNyQfd3c3MY64DIdFNAujXr1/cHyciIrXE2rNx98rwvh1YRHTPZVsYAiO8bw/FK4G+Saf3CbG64n1SxFPVY5a7F7t7cc+ePZvbLBERaaTYejZmdjhwiLt/GrbPBW4HlgATgLvC++JwyhJgipktIJoM8Im7V5nZUuDOpEkB5wLT3H2XmVWb2QhgDXAlcH9c7RFpS8qqqrnswdU13+NJfFG0pKg344er9y5tT5zDaL2ARWE2ckfgcXd/3szWAk+a2dXAe8ClofyzwAVAObAbuAogJJU7gLWh3O3uvitsXw/MAboCz4WXSE5L96XQROJRspG2KLZk4+5bgJNSxHcCZ6WIOzA5zbVmA7NTxEuBQc2urEgWGT+8X8qEctmDqzNQG5GG0XI1IiISOyUbERGJnZKNiIjETslGRERip2QjIiKxU7IREZHYKdmIiEjslGxERCR2SjYiIhI7JRsREYmdko2IiMROyUZERGKnZCMiIrFTshERkdgp2YiISOyUbEREJHZKNiIiEjslGxERiZ2SjYiIxE7JRkREYqdkIyIisVOyERGR2MWebMysg5n90cx+H/b7m9kaMys3syfM7NAQ7xz2y8PxgqRrTAvxN83svKT4mBArN7Nb4m6LiIg0TcdW+IwbgTeAvLB/N3Cvuy8wsweAq4GZ4f0jd/+6mY0L5S4zs0JgHHACcCzwX2b2D+FavwbOASqAtWa2xN3LWqFNIjUeX/M+i9dXAlBWVQ1AYX4eZVXVFObn1XWqSLvR6J6NmR1tZoMbWLYPcCHwUNg3YDSwMBSZC1wctkvCPuH4WaF8CbDA3fe6+ztAOTAsvMrdfYu77wMWhLIirWrx+soDkkwiwRTm51FS1DuTVRNpMxrUszGzF4GLQvl1wHYz+3/u/k/1nPor4GbgyLB/DPCxu+8P+xVA4v/G3sBWAHffb2afhPK9gVeTrpl8ztZa8eFp6j8JmATQr1+/eqos0niF+Xk8ce3ITFdDpM1qaM/mKHevBr4LzHP34cDZdZ1gZt8Btrv7umbWsdncfZa7F7t7cc+ePTNdHRGRdqeh92w6mlk+cCnwzw0851vARWZ2AdCF6J7NfUA3M+sYejd9gMpQvhLoC1SYWUfgKGBnUjwh+Zx0cRERaUMa2rO5DVhKdI9krZkNADbXdYK7T3P3Pu5eQHSDf4W7XwGsBMaGYhOAxWF7SdgnHF/h7h7i48Jstf7AQOA1YC0wMMxuOzR8xpIGtkdERFpRQ3s2Ve5eMynA3beY2b838TN/Aiwws58DfwQeDvGHgUfNrBzYRZQ8cPeNZvYkUAbsBya7+xcAZjaFKAl2AGa7+8Ym1klERGLU0GRzPzCkAbGU3P1F4MWwvYVoJlntMnuA76U5/xfAL1LEnwWebUgdREQkc+pMNmY2EjgV6GlmyTPP8oh6EyIiIvWqr2dzKHBEKHdkUryaL++7iIiI1KnOZOPuLwEvmdkcd3+vleokIiI5pqH3bDqb2SygIPkcdx8dR6VERCS3NDTZPAU8QLTszBfxVUdERHJRQ5PNfnefGWtNREQkZzX0S52/M7PrzSzfzLonXrHWTEREckZDezaJb/b/OCnmwICWrY6IiOSiBiUbd+8fd0VERCR3NWgYzcwOM7N/CTPSMLOBYVVnERGRejX0ns0jwD6i1QQgWl3557HUSEREck5Dk83X3P3fgM8B3H03YLHVSkREckpDk80+M+tKNCkAM/sasDe2WomISE5p6Gy0W4Hngb5m9hjRg9EmxlQnERHJMQ2djbbMzNYBI4iGz2509w9jrZmIiOSMBiUbM/sd8DiwxN3/Gm+VRKSpyqqquezB1ZRVVQNQmJ9HSVFvxg/vl+GaSXvX0Hs29wCnAWVmttDMxppZlxjrJSKNVFLUm8L8PCBKMoX5eZRVVbN4fWWGaybS8GG0xKMGOgCjgWuA2UQPURORNmD88H4H9WAue3B1hmojcqCGThAgzEb7R+AyosdBz42rUiIiklsaes/mSWAY0Yy0/wu85O5/j7NiIiKSOxras3kYuNzd9SwbadceX/M+i9dXHnADvqyquuZeiYikVucEATO7GcDdlwLfrXXsznrO7WJmr5nZn8xso5ndFuL9zWyNmZWb2RNmdmiIdw775eF4QdK1poX4m2Z2XlJ8TIiVm9ktjW28SGMlEk3iBjx8OeNLRNKrr2czDvi3sD2N6ImdCWOAn9Zx7l5gtLt/ZmadgFVm9hzwT8C97r7AzB4ArgZmhveP3P3rZjYOuBu4zMwKQz1OAI4F/svM/iF8xq+Bc4AKYK2ZLXH3sga1XKSJCvPzeOLakZmuhkhWqW/qs6XZTrV/AI98FnY7hZcTzWZbGOJzgYvDdglfTjpYCJxlZhbiC9x9r7u/A5QT3T8aBpS7+xZ33wcsCGVFRKSNqS/ZeJrtVPsHMbMOZrYe2A4sB94GPnb3/aFIBZAYf+gNbAUIxz8BjkmO1zonXVxERNqY+obRTjKzaqJeTNewTdiv90udYUJBkZl1AxYB32hGXZvMzCYBkwD69dM3qUVEWludycbdO7TEh7j7x2a2EhgJdDOzjqH30ofo2TiE975AhZl1BI4CdibFE5LPSRev/fmzgFkAxcXF9fbIRESkZTV0uZpGM7OeoUeT+ELoOcAbwEpgbCg2AVgctpeEfcLxFe7uIT4uzFbrDwwEXgPWAgPD7LZDiSYRLImrPSIi0nQNXkGgCfKBuWGJm0OAJ93992ZWBiwws58DfyT6Dg/h/VEzKwd2ESUP3H1j+FJpGbAfmJz4vo+ZTQGWAh2A2e6+Mcb2iIhIE8WWbNx9A3ByivgWoplkteN7gO+ludYvgF+kiD8LPNvsyoqISKxiG0YTERFJULIREZHYKdmIiEjslGxERCR2SjYiIhI7JRsREYmdko2IiMROyUZERGKnZCMiIrFTshERkdgp2YiISOyUbEREJHZKNiIiEjslGxERiZ2SjYiIxC7Oh6eJZK3H17zP4vUHP2W8rKqawvy8DNRIJLupZyOSwuL1lZRVVQNRgklsF+bnUVLUO5NVE8lK6tmIpFGYn8cT147MdDVEcoJ6NiIiEjslGxERiZ2SjYiIxE73bERyXFlVNZc9uPqgeElRb8YP75eBGkl7FFvPxsz6mtlKMyszs41mdmOIdzez5Wa2ObwfHeJmZjPMrNzMNpjZkKRrTQjlN5vZhKT4UDN7PZwzw8wsrvaIZKOSot41U7WTZ9WVVVWnnNotEpc4ezb7gZvc/Q9mdiSwzsyWAxOBF9z9LjO7BbgF+AlwPjAwvIYDM4HhZtYdmA4UAx6us8TdPwplrgHWAM8CY4DnYmyTSFYZP7xfyt5Lqp6OSJxi69m4e5W7/yFsfwq8AfQGSoC5odhc4OKwXQLM88irQDczywfOA5a7+66QYJYDY8KxPHd/1d0dmJd0LRERaUNaZYKAmRUAJxP1QHq5e1U49AHQK2z3BrYmnVYRYnXFK1LEU33+JDMrNbPSHTt2NK8xIiLSaLEnGzM7AngamOru1cnHQo/E466Du89y92J3L+7Zs2fcHyciIrXEmmzMrBNRonnM3X8bwtvCEBjhfXuIVwJ9k07vE2J1xfukiIuISBsT52w0Ax4G3nD3f086tARIzCibACxOil8ZZqWNAD4Jw21LgXPN7Ogwc+1cYGk4Vm1mI8JnXZl0LRERaUPinI32LeAHwOtmtj7EfgrcBTxpZlcD7wGXhmPPAhcA5cBu4CoAd99lZncAa0O52919V9i+HpgDdCWahaaZaCIibVBsycbdVwHpvvdyVoryDkxOc63ZwOwU8VJgUDOqKSIirUDL1YiISOyUbEREJHZaG03ateQnciY/IE1P5BRpWerZSLuW/ETOwvy8mgSjJ3KKtCz1bKTd0xM5ReKnno2IiMROyUZERGKnZCMiIrFTshERkdgp2YiISOyUbEREJHZKNiIiEjt9z0aknSqrquayB1cfECsp6s344f0yVCPJZUo2Iu1Q8uoIiRUUEpRsJA5KNiLt0Pjh/Q5KKrV7OSItSfdsREQkdurZSLuRaoVnQKs7i7QCJRtpNxIrPCev7gxodWeRVqBkI+2KVngWyQzdsxERkdgp2YiISOxiSzZmNtvMtpvZn5Ni3c1suZltDu9Hh7iZ2QwzKzezDWY2JOmcCaH8ZjObkBQfamavh3NmmJnF1RYREWmeOHs2c4AxtWK3AC+4+0DghbAPcD4wMLwmATMhSk7AdGA4MAyYnkhQocw1SefV/iwREWkjYks27v4ysKtWuASYG7bnAhcnxed55FWgm5nlA+cBy919l7t/BCwHxoRjee7+qrs7MC/pWiIi0sa09my0Xu5eFbY/AHqF7d7A1qRyFSFWV7wiRVzkgO/TJEtMexaR1pexCQKhR+Kt8VlmNsnMSs2sdMeOHa3xkZJBie/TQJRgEtuF+Xn6To1IhrR2z2abmeW7e1UYCtse4pVA36RyfUKsEhhVK/5iiPdJUT4ld58FzAIoLi5ulQQnmaXv0zRNqpWgQatBS/O1ds9mCZCYUTYBWJwUvzLMShsBfBKG25YC55rZ0WFiwLnA0nCs2sxGhFloVyZdS0SaoKSod8phxrKq6pTDkiKNEVvPxszmE/VKephZBdGssruAJ83sauA94NJQ/FngAqAc2A1cBeDuu8zsDmBtKHe7uycmHVxPNOOtK/BceIlIE6VaCRq0GrS0jNiSjbtfnubQWSnKOjA5zXVmA7NTxEuBQc2po4iItA6tICAiIrHTQpyS1VJNc9YUZ5G2Rz0byWrJ05wTNMVZpO1Rz0aynqY5x09ToqW5lGxEpE7JvcTkL8gmtpVspCGUbESkTpoSLS1B92xERCR26tlIVkiedVZ7KEczz0TaPvVsJCskzzorzM+rSTCaeSaSHdSzkayhWWdtT6pZapqhJqko2Uibkxgy03BZ25aqR6kZapKOko20OYlEk5xcNFzW9qSapaYZapKOko20SRoyE8ktSjaSMXp8c25K3MdJHgYF3ctp75RsJGNSDZeBhsyyWfLPLfnnuuadXax5Z9dBf1woAbUfSjYSu/p6MBouyx3pVhtItzp34hzJfUo20qJS/aOy5p3o4arD+3c/IK4eTPuRbjKBFvhsP5RspEUlD40l/nId3r+7/vGQg6T7QyPdkFviHP0eZSeLnsjcfhQXF3tpaWmmq5H1NDQmcUn3u5Wuh6wEFD8zW+fuxc25hno2Ui8NjUlrasx9n7p6QakoMWWOejbtVLq/HlPRX5TSVtX3e5w8/Trd73E6+v3+Ukv0bJRsckRjkgekTyDp6H88yXZN/QOr9veF4tKW/x9TsgHMbAxwH9ABeMjd76qrfDYlm5bofdSlLf9yi2RSY/94a66m/P/bmp687tT2fc/GzDoAvwbOASqAtWa2xN3Lmnvt1v5lS2hqt18zvkRaTrr7RnHJ1L83DZH4N6m5sjrZAMOAcnffAmBmC4ASIG2y2bLjrw1aLDAT3ejan6EEItI+tHZya4zLHlzNn1vgOlk9jGZmY4Ex7v4/w/4PgOHuPqVWuUnApLA7CFrkv11b1AP4MNOViJHal93Uvux1vLsf2ZwLZHvPpkHcfRYwC8DMSps79thW5XLbQO3Ldmpf9jKzZt/ozvbHQlcCfZP2+4SYiIi0IdmebNYCA82sv5kdCowDlmS4TiIiUktWD6O5+34zmwIsJZr6PNvdN9Zz2qz4a5Yxudw2UPuyndqXvZrdtqyeICAiItkh24fRREQkCyjZiIhI7HI62ZhZNzNbaGabzOwNMxtpZt3NbLmZbQ7vR2e6nk1hZseb2fqkV7WZTc2V9gGY2f82s41m9mczm29mXcJkkDVmVm5mT4SJIVnHzG4M7dpoZlNDLGt/dmY228y2m9mfk2Ip22ORGeFnuMHMhmSu5g2Tpn3fCz+/v5tZca3y00L73jSz81q/xo2Tpn2/DP92bjCzRWbWLelYo9uX08mGaM205939G8BJwBvALcAL7j4QeCHsZx13f9Pdi9y9CBgK7AYWkSPtM7PewA1AsbsPIpoAMg64G7jX3b8OfARcnblaNo2ZDQKuIVoB4yTgO2b2dbL7ZzcHGFMrlq495wMDw2sSMLOV6tgcczi4fX8Gvgu8nBw0s0Ki39UTwjn/EZbWasvmcHD7lgOD3H0w8BYwDZrevpxNNmZ2FHA68DCAu+9z94+JlrOZG4rNBS7ORP1a2FnA2+7+HrnVvo5AVzPrCBwGVAGjgYXheLa275vAGnff7e77gZeI/tHK2p+du78M7KoVTteeEmCeR14FuplZfqtUtIlStc/d33D3N1MULwEWuPted38HKCf6w6LNStO+ZeH3E+BVou8xQhPbl7PJBugP7AAeMbM/mtlDZnY40Mvdq0KZD4BeGathyxkHzA/bOdE+d68E7gHeJ0oynwDrgI+T/geoALLxSW1/Bk4zs2PM7DDgAqIvJ+fEzy5Juvb0BrYmlcvWn2M6udi+HwLPhe0mtS+Xk01HYAgw091PBv5KrWEJj+Z9Z/Xc73DP4iLgqdrHsrl9YXy/hOiPhmOBwzm4m5+V3P0NouHAZcDzwHrgi1plsvZnl0qutac9MbN/BvYDjzXnOrmcbCqACndfE/YXEiWfbYkue3jfnqH6tZTzgT+4+7awnyvtOxt4x913uPvnwG+BbxENuSS+jJy1yxO5+8PuPtTdTye69/QWufOzS0jXnlxfZipn2mdmE4HvAFf4l1/KbFL7cjbZuPsHwFYzOz6EziJ69MASYEKITQAWZ6B6LelyvhxCg9xp3/vACDM7zMyML39+K4GxoUzWts/MvhLe+xHdr3mc3PnZJaRrzxLgyjArbQTwSdJwWy5YAowzs85m1p9oIsRrGa5To1n0YMqbgYvcfXfSoaa1z91z9gUUAaXABuAZ4GjgGKKZMZuB/wK6Z7qezWjf4cBO4KikWC617zZgE9E9jkeBzsCA8ItdTjR02DnT9Wxi214hSp5/As7K9p8d0R88VcDnRKMKV6drD2BEDz18G3idaMZhxtvQhPZdErb3AtuApUnl/zm0703g/EzXv4ntKye6N7M+vB5oTvu0XI2IiMQuZ4fRRESk7VCyERGR2CnZiIhI7JRsREQkdko2IiISOyUbERGJnZKNSCOZ2SO1Hu/wgZnVXoSyIdcpMLO/mdn6pFgvM3vczLaY2TozW21ml9RxjZW1l3gPj5qYaWZdQ/32mVmPxtZPpCUp2Yg0krtf5V8+3uESonWjJjbxcm+H6xBWSngGeNndB7j7UKJFVvukP535oUyyccB8d/9buPZfmlg3kRajZCPSRKG38Dxwh7svaYFLjgb2ufsDiYC7v+fu94fP+76ZvRZ6Kw+GZ4gsBC5MPETOzAqIFi59pQXqI9JilGxEmiA8GuB3wJPu/mALXfYE4A9pPu+bwGXAt0Jv5QuixRF3ES3fc34oOi7USUuDSJvSsf4iIpIs9CgWAJvc/Wcxfs6vgW8D+4gePjYUWBuNttGVL1dRTgylLQ7vWff0Usl9SjYijfcfQCeiRzvXMLNORIuHHkY0anBT8r6731DPdTcC/yOx4+6Tw1BdKdHilXPdfVqK8xYD95rZEOAwd1/XpFaJxEjDaCKNYGbTiXoY3/MvnxiaMImox/ExcFSK/fqsALqY2f9Kih0W3l8AxiY9mqC7mR0H4O6fET16YTYHPm5CpM1Qz0akgcLN91uBd4FVYTgL4E13vww4GZjs7ntD+YeS9+vj7m5mFxP1Um4meqz5X4GfuHuZmf0LsMzMDiFaCn4y8F44fT6wiINnpom0CXrEgEgLMbN/BMYTPQNkBdFQW82+uz9fq3wB8Ht3HxRzvd4lembMh3F+jkhdlGxEMsTM+gL/DexMfNemha/fFVgN9ARODDPXRDJCyUZERGKnCQIiIhI7JRsREYmdko2IiMROyUZERGKnZCMiIrFTshERkdgp2YiISOyUbEREJHb/H4dn7kG5ueIlAAAAAElFTkSuQmCC\n",
       "text/plain": [
-       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
+       "<Figure size 432x288 with 1 Axes>"
       ]
      },
      "metadata": {},
@@ -154,46 +149,28 @@
     }
    ],
    "source": [
-    "%matplotlib widget\n",
+    "fig, axes = plt.subplots()\n",
+    "first = True\n",
+    "\n",
     "async def plot_stream(accumulator_stream):\n",
+    "  global first\n",
+    "  count = 0\n",
     "  async for coffea_info in accumulator_stream:\n",
-    "    # Need to ask coffea folks how to anomate this!\n",
-    "    hist.plot1d(coffea_info['mass'])\n",
+    "    hist.plot1d(coffea_info['mass'], ax=axes)\n",
+    "\n",
+    "    count += 1\n",
+    "    plt.text(0.95, 0.8, f'Chunks of data: {count}', horizontalalignment='right', transform=axes.transAxes)\n",
+    "\n",
+    "    # Either display it or update a previous version of the plot\n",
+    "    if first:\n",
+    "        display(fig, display_id='mass_update')\n",
+    "        first = False\n",
+    "    else:\n",
+    "        update_display(fig, display_id='mass_update')\n",
     "  return coffea_info\n",
     "\n",
-    "result = await plot_stream(executor.execute(analysis, datasource))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1b6c2ba6bfb0469e8d1016a9f0ead3df",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Canvas(toolbar=Toolbar(toolitems=[('Home', 'Reset original view', 'home', 'home'), ('Back', 'Back to previous …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
-   "source": [
-    "%matplotlib widget\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "data = np.random.normal(size=100)\n",
-    "fig, axes = plt.subplots()\n",
-    "for _ in range(10):\n",
-    "    plt.hist(data)\n",
-    "    # display(fig)\n",
-    "sleep(10)"
+    "await plot_stream(executor.execute(analysis, datasource))\n",
+    "plt.close()  # Prevents another copy of the plot showing up in the notebook"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # ServiceX access
-servicex==2.2b1
+servicex==2.2b5
 servicex_clients
 
 # Get around a bug in windows (which is fixed in the windows source tree,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # ServiceX access
 servicex==2.2b5
-servicex_clients
 
 # Get around a bug in windows (which is fixed in the windows source tree,
 # but will take until Jan to be released! Grrr! Damm their security tests!).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,18 @@
-# Need some special fixed clients for this test
+# ServiceX access
 servicex==2.2b1
+servicex_clients
 
 # Get around a bug in windows (which is fixed in the windows source tree,
 # but will take until Jan to be released! Grrr! Damm their security tests!).
 numpy==1.19.3
 
-servicex_clients
+# Processing library with schema
 coffea
+
+# Notebook interactive items
 jupyterlab
+ipympl
+
+# Distributed processing libraries
 git+https://github.com/funcx-faas/funcX.git@async_interface#subdirectory=funcx_sdk
-
 dask[distributed]
-
-# Some helper libraries
-aiostream
-tenacity
-
-# For development help
-# pytest
-flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Need some special fixed clients for this test
-servicex==2.2a2
+servicex==2.2b1
 
 # Get around a bug in windows (which is fixed in the windows source tree,
 # but will take until Jan to be released! Grrr! Damm their security tests!).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,6 @@
 # but will take until Jan to be released! Grrr! Damm their security tests!).
 numpy==1.19.3
 
-# Processing library with schema
-coffea
-
 # Notebook interactive items
 jupyterlab
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,6 @@ coffea
 
 # Notebook interactive items
 jupyterlab
-ipympl
 
 # Distributed processing libraries
 git+https://github.com/funcx-faas/funcX.git@async_interface#subdirectory=funcx_sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
-# ServiceX access
-servicex==2.2b5
-
 # Get around a bug in windows (which is fixed in the windows source tree,
 # but will take until Jan to be released! Grrr! Damm their security tests!).
 numpy==1.19.3

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="sx_multi",
     version="0.0.1",
     packages=['sx_multi'],
-    install_requires=['aiostream', 'tenacity'],
+    install_requires=['aiostream', 'tenacity', 'servicex_clients'],
     scripts=[],
     extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     name="sx_multi",
     version="0.0.1",
     packages=['sx_multi'],
+    install_requires=['aiostream', 'tenacity'],
     scripts=[],
     extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="sx_multi",
     version="0.0.1",
     packages=['sx_multi'],
-    install_requires=['aiostream', 'tenacity', 'servicex_clients'],
+    install_requires=['aiostream', 'tenacity', 'servicex==2.2b5', 'servicex_clients'],
     scripts=[],
     extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="sx_multi",
     version="0.0.1",
     packages=['sx_multi'],
-    install_requires=['aiostream', 'tenacity', 'servicex==2.2b5', 'servicex_clients', 'coffea'],
+    install_requires=['aiostream', 'tenacity', 'servicex==2.2b5', 'servicex_clients', 'coffea', 'dill'],
     scripts=[],
     extras_require=extras_require
 )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="sx_multi",
     version="0.0.1",
     packages=['sx_multi'],
-    install_requires=['aiostream', 'tenacity', 'servicex==2.2b5', 'servicex_clients'],
+    install_requires=['aiostream', 'tenacity', 'servicex==2.2b5', 'servicex_clients', 'coffea'],
     scripts=[],
     extras_require=extras_require
 )

--- a/src/sx_multi/dask_executor.py
+++ b/src/sx_multi/dask_executor.py
@@ -36,9 +36,9 @@ class DaskExecutor(Executor):
 
         Args:
             client_addr (Optional[str]): If `None` then create a local cluster that runs in-process.
-                                         Otherwise connect to an already existing cluster.  
+                                         Otherwise connect to an already existing cluster.
         '''
-        self.dask = Client(processes=False, threads_per_worker=10) if client_addr is None \
+        self.dask = Client(threads_per_worker=10, asynchronous=True) if client_addr is None \
             else Client(client_addr, asynchronous=True)
 
     def run_async_analysis(self, file_url, tree_name, accumulator, process_func):

--- a/src/sx_multi/dask_executor.py
+++ b/src/sx_multi/dask_executor.py
@@ -25,13 +25,21 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from typing import Optional
 from dask.distributed import Client
 from sx_multi import run_coffea_processor, Executor
 
 
 class DaskExecutor(Executor):
-    def __init__(self, client_addr):
-        self.dask = Client(client_addr, asynchronous=True)
+    def __init__(self, client_addr: Optional[str] = None):
+        '''Create a Dask executor to process the analysis
+
+        Args:
+            client_addr (Optional[str]): If `None` then create a local cluster that runs in-process.
+                                         Otherwise connect to an already existing cluster.  
+        '''
+        self.dask = Client(processes=False, threads_per_worker=10) if client_addr is None \
+            else Client(client_addr, asynchronous=True)
 
     def run_async_analysis(self, file_url, tree_name, accumulator, process_func):
         data_result = self.dask.submit(run_coffea_processor,

--- a/src/sx_multi/data_source.py
+++ b/src/sx_multi/data_source.py
@@ -27,6 +27,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+from typing import AsyncGenerator
+
+from servicex.servicex import StreamInfoUrl
+
+
 class DataSource:
     def __init__(self, query, metadata={}, datasets=[]):
         self.query = query
@@ -34,7 +39,15 @@ class DataSource:
         self.schema = None
         self.datasets = datasets
 
-    async def stream_result_file_urls(self):
+    async def stream_result_file_urls(self) -> AsyncGenerator[StreamInfoUrl, None]:
+        '''Launch all datasources at once
+
+        TODO: This is currently sync (that outter for loop does one datasource and then the next).
+        Need to move to a different paradigm. Perhaps using the `aiostream` library.
+
+        Yields:
+            [type]: [description]
+        '''
         for dataset in self.datasets:
-            async for file in dataset.get_data_rootfiles_minio_async(self.query.value()):
+            async for file in dataset.get_data_rootfiles_url_stream(self.query.value()):
                 yield file


### PR DESCRIPTION
This PR will use the new URL streaming interface from `servicex`'s front-end code. It also makes a number of other updates to get the `dask` demo notebook working.

- Update to the new beta verison of servicex and the modern version of coffea. Do not muck with the versions of awkard1 or uproot3 or awkward or... many hours of lost time will ensue.
- Fix how we create a `dask` local cluster when not running with a remote one
- Fix the dask demo notebook so the plot updates in place
- Fix up a number of type errors in the code, which caught some small bugs
- Remove some print debug statements
- Normalize packages pulled in by `requirements.txt` and `setup.py`. I'm sure it isn't perfect yet, but hopefully it is closer.

N.B. 

- `ray` and `funcx` are not updated.
- The CI tests are failing as we need to import the `funcx` library. However, the proper version has to be installed directly from github, so ignoring that issue until a packaged version of funcx with the changes we need can be added to the `setup.py` file.
