### PR TITLE
build: Remove universal wheel flag

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,9 +24,6 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
-[bdist_wheel]
-universal = 1
-
 [options]
 package_dir =
     = src


### PR DESCRIPTION
* Remove universal wheel setting as library is Python 3 only
   - Fixes py2.py3 tag naming scheme for wheels
   
For posterity (and self reference), in the [PyPA's "Packaging and distributing projects" guide the section on wheels](https://packaging.python.org/guides/distributing-packages-using-setuptools/#universal-wheels) notes that

> Only use the `--universal setting`, if:
>
> 1. Your project runs on Python 2 and 3 with no changes (i.e. it does not require 2to3).
> 2. Your project does not have any C extensions.

This PR is motivated by https://github.com/scikit-hep/pyhf/pull/1295